### PR TITLE
Add/paste tracklist get show assets

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,12 +16,12 @@ import { getApiToken, getView } from "./store/app/selectors";
 
 import AuthoriseSpotify from "./components/AuthoriseSpotify.js";
 
-import Playlists from "./components/Playlists.js";
 import Songs from "./components/Songs.js";
 import Albums from "./components/Albums.js";
 import CoverGrid from "./components/CoverGrid.js";
 
 import PlaylistImporter from "./components/PlaylistImporter.js";
+import TracklistProcessor from "./components/TracklistProcessor.js";
 
 import useUrlHashParams from "./lib/useUrlHashParams.js";
 
@@ -53,8 +53,9 @@ function AppContent() {
     return <AuthoriseSpotify />;
   }
 
-  if (view === "playlists") {
-    return <Playlists />;
+  // Default to the new tracklist processor as the main flow
+  if (!view || view === "playlists" || view === "tracklist-processor") {
+    return <TracklistProcessor />;
   }
 
   if (view === "albums") {

--- a/src/components/TracklistProcessor.js
+++ b/src/components/TracklistProcessor.js
@@ -87,6 +87,37 @@ const useStyles = makeStyles((theme) => ({
     opacity: 0.5,
     pointerEvents: 'none',
   },
+  playlistCanvas: {
+    marginBottom: theme.spacing(3),
+  },
+  canvasContainer: {
+    width: '1111px',
+    height: '1111px',
+    border: '2px solid #ddd',
+    borderRadius: theme.spacing(1),
+    backgroundColor: '#ffffff',
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    margin: '0 auto',
+    maxWidth: '100%', // Responsive fallback
+  },
+  canvasTracklistSection: {
+    flex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: theme.spacing(4),
+  },
+  tracklistContent: {
+    width: '100%',
+    textAlign: 'left',
+  },
+  tracklistLine: {
+    marginBottom: theme.spacing(1),
+    fontSize: '1rem',
+    lineHeight: 1.5,
+  },
 }));
 
 function TrackResult({ result, index, onUpdateResult, apiToken }) {
@@ -126,7 +157,7 @@ function TrackResult({ result, index, onUpdateResult, apiToken }) {
         const artists = track.artists.map(a => a.name).join(' + ');
         return `**${artists}** – _${track.name}_`;
       } else if (result.isNewTrack) {
-        return '**Artist** – _Track Title_';
+        return '**Artist** – _Track title_';
       } else {
         return `**${result.originalText}** – _[NOT FOUND]_`;
       }
@@ -198,7 +229,7 @@ function TrackResult({ result, index, onUpdateResult, apiToken }) {
         const artists = track.artists.map(a => a.name).join(' + ');
         markdownText = `**${artists}** – _${track.name}_`;
       } else if (result.isNewTrack) {
-        markdownText = '**Artist** – _Track Title_';
+        markdownText = '**Artist** – _Track title_';
       } else {
         markdownText = `**${result.originalText}** – _[NOT FOUND]_`;
       }
@@ -442,7 +473,7 @@ function TrackResult({ result, index, onUpdateResult, apiToken }) {
                   </Typography>
                 ) : result.isNewTrack ? (
                   <Typography variant="body2" color="textSecondary">
-                    Click "Custom" or "Refine Search" to add track details
+                    Click "Custom" or "Refine search" to add track details
                   </Typography>
                 ) : (
                   <Typography variant="body2" color="error">
@@ -466,7 +497,7 @@ function TrackResult({ result, index, onUpdateResult, apiToken }) {
                         }
                       }}
                     >
-                      Refine Search
+                      Refine search
                     </Button>
                     <Button 
                       size="small" 
@@ -529,7 +560,7 @@ function TrackResult({ result, index, onUpdateResult, apiToken }) {
               // Custom track mode
               <>
                 <Typography variant="body2" gutterBottom>
-                  <strong>Custom Track:</strong>
+                  <strong>Custom track:</strong>
                 </Typography>
                 
                 <Grid container spacing={2}>
@@ -546,7 +577,7 @@ function TrackResult({ result, index, onUpdateResult, apiToken }) {
                   </Grid>
                   <Grid item xs={12} sm={6}>
                     <TextField
-                      label="Track Title"
+                      label="Track title"
                       size="small"
                       fullWidth
                       value={customTitle}
@@ -575,7 +606,7 @@ function TrackResult({ result, index, onUpdateResult, apiToken }) {
                     />
                     <label htmlFor={`cover-upload-${index}`}>
                       <Button variant="outlined" component="span" size="small" fullWidth>
-                        Upload Cover Art
+                        Upload cover art
                       </Button>
                     </label>
                   </Grid>
@@ -583,7 +614,7 @@ function TrackResult({ result, index, onUpdateResult, apiToken }) {
 
                 {customCoverImageUrl && (
                   <Box mt={2}>
-                    <Typography variant="body2" gutterBottom>Cover Preview:</Typography>
+                    <Typography variant="body2" gutterBottom>Cover preview:</Typography>
                     <img 
                       src={customCoverImageUrl} 
                       alt="Cover preview" 
@@ -603,7 +634,7 @@ function TrackResult({ result, index, onUpdateResult, apiToken }) {
                     onClick={handleSaveCustom}
                     disabled={!customArtist.trim() || !customTitle.trim()}
                   >
-                    Save Custom Track
+                    Save custom track
                   </Button>
                 </Box>
               </>
@@ -611,7 +642,7 @@ function TrackResult({ result, index, onUpdateResult, apiToken }) {
               // Spotify search mode
               <>
                 <Typography variant="body2" gutterBottom>
-                  <strong>Refine Search:</strong>
+                  <strong>Refine search:</strong>
                 </Typography>
             
             <Grid container spacing={2} alignItems="center">
@@ -677,7 +708,7 @@ function TrackResult({ result, index, onUpdateResult, apiToken }) {
 
             {searchResults.length > 0 && (
               <Box mt={2}>
-                <Typography variant="body2" gutterBottom>
+                                <Typography variant="body2" gutterBottom>
                   <strong>Select the correct track:</strong>
                 </Typography>
                 {searchResults.slice(0, 5).map((track, trackIndex) => (
@@ -726,7 +757,7 @@ function CoverArtGrid({ coverArtData }) {
   return (
     <div className={classes.coverGrid}>
       <Typography variant="h5" gutterBottom>
-        Cover Art Grid
+        Cover art grid
       </Typography>
       <Grid container spacing={2}>
         {coverArtData.map((cover, index) => (
@@ -740,6 +771,117 @@ function CoverArtGrid({ coverArtData }) {
           </Grid>
         ))}
       </Grid>
+    </div>
+  );
+}
+
+function PlaylistCanvas({ coverArtData, markdown }) {
+  const classes = useStyles();
+  const [fontSize, setFontSize] = React.useState(16); // Default font size in px
+  const [leftMargin, setLeftMargin] = React.useState(0); // Default left margin in em
+  
+  if (!markdown) {
+    return null;
+  }
+
+  // Parse markdown into structured list
+  const tracklistLines = markdown.split('\n').filter(line => line.trim());
+
+  const adjustLeftMargin = (delta) => {
+    setLeftMargin(prev => Math.max(0, Math.min(10, prev + delta))); // Clamp between 0 and 10em
+  };
+
+  return (
+    <div className={classes.playlistCanvas}>
+      {/* Controls */}
+      <Box display="flex" alignItems="center" gap={4} mb={2}>
+        {/* Font Size Control */}
+        <Box display="flex" alignItems="center" gap={1} minWidth={150}>
+          <Typography variant="body2" style={{ minWidth: 'fit-content' }}>
+            Font size:
+          </Typography>
+          <input
+            type="range"
+            min="12"
+            max="36"
+            value={fontSize}
+            onChange={(e) => setFontSize(parseInt(e.target.value))}
+            style={{ flex: 1 }}
+          />
+          <Typography variant="body2" style={{ minWidth: '30px' }}>
+            {fontSize}px
+          </Typography>
+        </Box>
+        
+        {/* Left Margin Control */}
+        <Box display="flex" alignItems="center" gap={1}>
+          <Typography variant="body2" style={{ minWidth: 'fit-content' }}>
+            Left margin:
+          </Typography>
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={() => adjustLeftMargin(-0.5)}
+            style={{ minWidth: '30px', padding: '4px' }}
+          >
+            ←
+          </Button>
+          <Typography variant="body2" style={{ minWidth: '50px', textAlign: 'center' }}>
+            {leftMargin}em
+          </Typography>
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={() => adjustLeftMargin(0.5)}
+            style={{ minWidth: '30px', padding: '4px' }}
+          >
+            →
+          </Button>
+        </Box>
+      </Box>
+      
+      <div className={classes.canvasContainer}>
+        {/* Tracklist Section */}
+        <div className={classes.canvasTracklistSection}>
+          <div 
+            className={classes.tracklistContent}
+            style={{ 
+              marginLeft: `${leftMargin}em`,
+              fontSize: `${fontSize}px`
+            }}
+          >
+            {tracklistLines.map((line, index) => {
+              // Parse markdown formatting for display
+              const renderLine = (text) => {
+                const parts = text.split(/(\*\*.*?\*\*|_.*?_|\[NZ\])/);
+                
+                return parts.map((part, idx) => {
+                  if (part.startsWith('**') && part.endsWith('**')) {
+                    return <strong key={idx}>{part.slice(2, -2)}</strong>;
+                  } else if (part.startsWith('_') && part.endsWith('_')) {
+                    return <em key={idx}>{part.slice(1, -1)}</em>;
+                  } else if (part === '[NZ]') {
+                    return <span key={idx} style={{ color: '#1976d2', fontWeight: 'bold' }}>{part}</span>;
+                  } else {
+                    return part;
+                  }
+                });
+              };
+              
+              return (
+                <Typography 
+                  key={index} 
+                  variant="body1" 
+                  className={classes.tracklistLine}
+                  style={{ fontSize: 'inherit' }} // Inherit from parent
+                >
+                  {renderLine(line)}
+                </Typography>
+              );
+            })}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }
@@ -759,10 +901,10 @@ function MarkdownOutput({ markdown }) {
     <div>
       <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
         <Typography variant="h5">
-          Tracklist Markdown
+          Tracklist markdown
         </Typography>
         <Button variant="outlined" size="small" onClick={handleCopy}>
-          Copy to Clipboard
+          Copy to clipboard
         </Button>
       </Box>
       <Paper className={classes.markdownOutput}>
@@ -840,7 +982,7 @@ function TracklistProcessor() {
       <div className={classes.header}>
         <div>
           <Typography variant="h4" gutterBottom>
-            Tracklist to Cover Art & Markdown
+            Tracklist to cover art & markdown
           </Typography>
           <Chip 
             label="✓ Connected to Spotify" 
@@ -874,7 +1016,7 @@ function TracklistProcessor() {
         onClick={handleProcess}
         disabled={isProcessing || !tracklistText.trim()}
       >
-        {isProcessing ? 'Processing...' : 'Process Tracklist'}
+        {isProcessing ? 'Processing...' : 'Process tracklist'}
       </Button>
 
       {isProcessing && (
@@ -889,7 +1031,7 @@ function TracklistProcessor() {
       {results.length > 0 && !isProcessing && (
         <Box mb={3}>
           <Typography variant="h6" gutterBottom>
-            Search Results
+            Search results
           </Typography>
           <Box mb={2}>
             <Chip 
@@ -914,13 +1056,15 @@ function TracklistProcessor() {
               onClick={handleAddTrack}
               startIcon={<span>+</span>}
             >
-              Add Track
+              Add track
             </Button>
           </Box>
         </Box>
       )}
 
       <CoverArtGrid coverArtData={coverArtData} />
+      
+      <PlaylistCanvas coverArtData={coverArtData} markdown={markdown} />
       
       <MarkdownOutput markdown={markdown} />
     </div>

--- a/src/components/TracklistProcessor.js
+++ b/src/components/TracklistProcessor.js
@@ -18,7 +18,9 @@ import { getApiToken } from "../store/app/selectors";
 import { 
   processTracklist, 
   generateCoverArtData, 
-  generateMarkdownTracklist 
+  generateMarkdownTracklist,
+  searchForTrackWithFields,
+  getTrackById
 } from "../lib/tracklistProcessor";
 
 const useStyles = makeStyles((theme) => ({
@@ -63,23 +65,213 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function TrackResult({ result, index }) {
+function TrackResult({ result, index, onUpdateResult, apiToken }) {
   const classes = useStyles();
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSearching, setIsSearching] = useState(false);
+  const [artistField, setArtistField] = useState('');
+  const [titleField, setTitleField] = useState('');
+  const [spotifyIdField, setSpotifyIdField] = useState('');
+  const [searchResults, setSearchResults] = useState([]);
+  
+  // Initialize fields when entering edit mode
+  const handleStartEdit = () => {
+    // Try to parse the original text into artist and title
+    const text = result.originalText;
+    const dashIndex = text.indexOf(' - ');
+    if (dashIndex > 0) {
+      setArtistField(text.substring(0, dashIndex).trim());
+      setTitleField(text.substring(dashIndex + 3).trim());
+    } else {
+      // If no dash, put everything in the title field
+      setArtistField('');
+      setTitleField(text.trim());
+    }
+    setSpotifyIdField('');
+    setSearchResults([]);
+    setIsEditing(true);
+  };
+
+  const handleCancelEdit = () => {
+    setIsEditing(false);
+    setSearchResults([]);
+  };
+
+  const handleSearchWithFields = async () => {
+    if (!artistField.trim() && !titleField.trim()) return;
+    
+    setIsSearching(true);
+    try {
+      const searchResult = await searchForTrackWithFields(apiToken, artistField, titleField);
+      setSearchResults(searchResult.tracks || []);
+    } catch (error) {
+      console.error('Error searching with fields:', error);
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  const handleSearchById = async () => {
+    if (!spotifyIdField.trim()) return;
+    
+    setIsSearching(true);
+    try {
+      const searchResult = await getTrackById(apiToken, spotifyIdField);
+      if (searchResult.found) {
+        setSearchResults([searchResult.bestMatch]);
+      } else {
+        setSearchResults([]);
+      }
+    } catch (error) {
+      console.error('Error searching by ID:', error);
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  const handleSelectTrack = (track) => {
+    // Update the result with the new track
+    const updatedResult = {
+      ...result,
+      bestMatch: track,
+      found: true,
+      tracks: [track, ...result.tracks]
+    };
+    onUpdateResult(index, updatedResult);
+    setIsEditing(false);
+  };
   
   return (
     <Card className={`${classes.trackResult} ${result.found ? classes.foundTrack : classes.notFoundTrack}`}>
       <CardContent>
-        <Typography variant="body2">
-          <strong>{index + 1}.</strong> {result.originalText}
-        </Typography>
-        {result.found ? (
-          <Typography variant="body2" color="textSecondary">
-            ✓ Found: {result.bestMatch.artists.map(a => a.name).join(', ')} - {result.bestMatch.name}
-          </Typography>
-        ) : (
-          <Typography variant="body2" color="error">
-            ✗ Not found
-          </Typography>
+        <Box display="flex" justifyContent="space-between" alignItems="flex-start">
+          <div style={{ flex: 1 }}>
+            <Typography variant="body2">
+              <strong>{index + 1}.</strong> {result.originalText}
+            </Typography>
+            {result.found ? (
+              <Typography variant="body2" color="textSecondary">
+                ✓ Found: {result.bestMatch.artists.map(a => a.name).join(', ')} - {result.bestMatch.name}
+              </Typography>
+            ) : (
+              <Typography variant="body2" color="error">
+                ✗ Not found
+              </Typography>
+            )}
+          </div>
+          
+          {!isEditing && (
+            <Button 
+              size="small" 
+              variant="outlined" 
+              onClick={handleStartEdit}
+              style={{ marginLeft: 16 }}
+            >
+              Refine Search
+            </Button>
+          )}
+        </Box>
+
+        {isEditing && (
+          <Box mt={2}>
+            <Typography variant="body2" gutterBottom>
+              <strong>Refine Search:</strong>
+            </Typography>
+            
+            <Grid container spacing={2} alignItems="center">
+              <Grid item xs={12} sm={4}>
+                <TextField
+                  label="Artist"
+                  size="small"
+                  fullWidth
+                  value={artistField}
+                  onChange={(e) => setArtistField(e.target.value)}
+                  variant="outlined"
+                />
+              </Grid>
+              <Grid item xs={12} sm={4}>
+                <TextField
+                  label="Title"
+                  size="small"
+                  fullWidth
+                  value={titleField}
+                  onChange={(e) => setTitleField(e.target.value)}
+                  variant="outlined"
+                />
+              </Grid>
+              <Grid item xs={12} sm={4}>
+                <Button
+                  variant="contained"
+                  size="small"
+                  onClick={handleSearchWithFields}
+                  disabled={isSearching || (!artistField.trim() && !titleField.trim())}
+                  fullWidth
+                >
+                  {isSearching ? 'Searching...' : 'Search'}
+                </Button>
+              </Grid>
+            </Grid>
+
+            <Box mt={2}>
+              <Grid container spacing={2} alignItems="center">
+                <Grid item xs={12} sm={8}>
+                  <TextField
+                    label="Spotify ID or URL"
+                    size="small"
+                    fullWidth
+                    value={spotifyIdField}
+                    onChange={(e) => setSpotifyIdField(e.target.value)}
+                    variant="outlined"
+                    placeholder="spotify:track:... or https://open.spotify.com/track/..."
+                  />
+                </Grid>
+                <Grid item xs={12} sm={4}>
+                  <Button
+                    variant="contained"
+                    size="small"
+                    onClick={handleSearchById}
+                    disabled={isSearching || !spotifyIdField.trim()}
+                    fullWidth
+                  >
+                    Get by ID
+                  </Button>
+                </Grid>
+              </Grid>
+            </Box>
+
+            {searchResults.length > 0 && (
+              <Box mt={2}>
+                <Typography variant="body2" gutterBottom>
+                  <strong>Select the correct track:</strong>
+                </Typography>
+                {searchResults.slice(0, 5).map((track, trackIndex) => (
+                  <Box 
+                    key={trackIndex} 
+                    p={1} 
+                    mb={1} 
+                    border={1} 
+                    borderColor="grey.300" 
+                    borderRadius={1}
+                    style={{ cursor: 'pointer' }}
+                    onClick={() => handleSelectTrack(track)}
+                  >
+                    <Typography variant="body2">
+                      <strong>{track.artists.map(a => a.name).join(', ')}</strong> - {track.name}
+                    </Typography>
+                    <Typography variant="caption" color="textSecondary">
+                      Album: {track.album.name} ({track.album.release_date?.substring(0, 4)})
+                    </Typography>
+                  </Box>
+                ))}
+              </Box>
+            )}
+
+            <Box mt={2} display="flex" gap={1}>
+              <Button size="small" onClick={handleCancelEdit}>
+                Cancel
+              </Button>
+            </Box>
+          </Box>
         )}
       </CardContent>
     </Card>
@@ -151,6 +343,19 @@ function TracklistProcessor() {
   const [results, setResults] = useState([]);
   const [coverArtData, setCoverArtData] = useState([]);
   const [markdown, setMarkdown] = useState('');
+
+  const handleUpdateResult = (index, updatedResult) => {
+    const newResults = [...results];
+    newResults[index] = updatedResult;
+    setResults(newResults);
+    
+    // Regenerate outputs with updated results
+    const coverData = generateCoverArtData(newResults);
+    setCoverArtData(coverData);
+    
+    const markdownOutput = generateMarkdownTracklist(newResults);
+    setMarkdown(markdownOutput);
+  };
 
   const handleProcess = async () => {
     if (!tracklistText.trim()) {
@@ -241,7 +446,13 @@ function TracklistProcessor() {
             />
           </Box>
           {results.map((result, index) => (
-            <TrackResult key={index} result={result} index={index} />
+            <TrackResult 
+              key={index} 
+              result={result} 
+              index={index} 
+              onUpdateResult={handleUpdateResult}
+              apiToken={apiToken}
+            />
           ))}
         </Box>
       )}

--- a/src/components/TracklistProcessor.js
+++ b/src/components/TracklistProcessor.js
@@ -1,0 +1,256 @@
+import React, { useState } from "react";
+import { useSelector } from "react-redux";
+import { 
+  TextField, 
+  Button, 
+  Typography, 
+  Box, 
+  Card, 
+  CardContent,
+  Grid,
+  LinearProgress,
+  Chip,
+  Paper
+} from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+
+import { getApiToken } from "../store/app/selectors";
+import { 
+  processTracklist, 
+  generateCoverArtData, 
+  generateMarkdownTracklist 
+} from "../lib/tracklistProcessor";
+
+const useStyles = makeStyles((theme) => ({
+  container: {
+    padding: theme.spacing(2),
+  },
+  textArea: {
+    marginBottom: theme.spacing(2),
+  },
+  processButton: {
+    marginBottom: theme.spacing(3),
+  },
+  coverGrid: {
+    marginBottom: theme.spacing(3),
+  },
+  coverImage: {
+    width: '100%',
+    height: 'auto',
+    borderRadius: theme.spacing(1),
+  },
+  trackResult: {
+    marginBottom: theme.spacing(1),
+  },
+  foundTrack: {
+    backgroundColor: theme.palette.success.light,
+  },
+  notFoundTrack: {
+    backgroundColor: theme.palette.error.light,
+  },
+  markdownOutput: {
+    backgroundColor: theme.palette.grey[100],
+    padding: theme.spacing(2),
+    fontFamily: 'monospace',
+    whiteSpace: 'pre-wrap',
+    marginTop: theme.spacing(2),
+  },
+  header: {
+    marginBottom: theme.spacing(3),
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+}));
+
+function TrackResult({ result, index }) {
+  const classes = useStyles();
+  
+  return (
+    <Card className={`${classes.trackResult} ${result.found ? classes.foundTrack : classes.notFoundTrack}`}>
+      <CardContent>
+        <Typography variant="body2">
+          <strong>{index + 1}.</strong> {result.originalText}
+        </Typography>
+        {result.found ? (
+          <Typography variant="body2" color="textSecondary">
+            ✓ Found: {result.bestMatch.artists.map(a => a.name).join(', ')} - {result.bestMatch.name}
+          </Typography>
+        ) : (
+          <Typography variant="body2" color="error">
+            ✗ Not found
+          </Typography>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function CoverArtGrid({ coverArtData }) {
+  const classes = useStyles();
+  
+  if (coverArtData.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={classes.coverGrid}>
+      <Typography variant="h5" gutterBottom>
+        Cover Art Grid
+      </Typography>
+      <Grid container spacing={2}>
+        {coverArtData.map((cover, index) => (
+          <Grid item xs={6} sm={4} md={3} lg={2} key={index}>
+            <img 
+              src={cover.coverImageUrl} 
+              alt={`${cover.artistName} - ${cover.albumName}`}
+              className={classes.coverImage}
+              title={`${cover.artistName} - ${cover.albumName}`}
+            />
+          </Grid>
+        ))}
+      </Grid>
+    </div>
+  );
+}
+
+function MarkdownOutput({ markdown }) {
+  const classes = useStyles();
+  
+  if (!markdown) {
+    return null;
+  }
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(markdown);
+  };
+
+  return (
+    <div>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+        <Typography variant="h5">
+          Tracklist Markdown
+        </Typography>
+        <Button variant="outlined" size="small" onClick={handleCopy}>
+          Copy to Clipboard
+        </Button>
+      </Box>
+      <Paper className={classes.markdownOutput}>
+        {markdown}
+      </Paper>
+    </div>
+  );
+}
+
+function TracklistProcessor() {
+  const classes = useStyles();
+  const apiToken = useSelector(getApiToken);
+  
+  const [tracklistText, setTracklistText] = useState('');
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [results, setResults] = useState([]);
+  const [coverArtData, setCoverArtData] = useState([]);
+  const [markdown, setMarkdown] = useState('');
+
+  const handleProcess = async () => {
+    if (!tracklistText.trim()) {
+      return;
+    }
+
+    setIsProcessing(true);
+    try {
+      const processedResults = await processTracklist(apiToken, tracklistText);
+      setResults(processedResults);
+      
+      const coverData = generateCoverArtData(processedResults);
+      setCoverArtData(coverData);
+      
+      const markdownOutput = generateMarkdownTracklist(processedResults);
+      setMarkdown(markdownOutput);
+      
+    } catch (error) {
+      console.error('Error processing tracklist:', error);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const foundCount = results.filter(r => r.found).length;
+  const totalCount = results.length;
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.header}>
+        <div>
+          <Typography variant="h4" gutterBottom>
+            Tracklist to Cover Art & Markdown
+          </Typography>
+          <Chip 
+            label="✓ Connected to Spotify" 
+            color="primary" 
+            size="small"
+          />
+        </div>
+      </div>
+      
+      <Typography variant="body1" gutterBottom color="textSecondary">
+        Paste your tracklist below and we'll search Spotify to generate a cover art grid and formatted markdown.
+      </Typography>
+
+      <TextField
+        className={classes.textArea}
+        multiline
+        rows={10}
+        variant="outlined"
+        fullWidth
+        placeholder="Paste your tracklist here... (e.g. 'Artist - Track Name' or numbered list)"
+        value={tracklistText}
+        onChange={(e) => setTracklistText(e.target.value)}
+        disabled={isProcessing}
+      />
+
+      <Button
+        className={classes.processButton}
+        variant="contained"
+        color="primary"
+        size="large"
+        onClick={handleProcess}
+        disabled={isProcessing || !tracklistText.trim()}
+      >
+        {isProcessing ? 'Processing...' : 'Process Tracklist'}
+      </Button>
+
+      {isProcessing && (
+        <Box mb={3}>
+          <LinearProgress />
+          <Typography variant="body2" align="center" style={{ marginTop: 8 }}>
+            Searching Spotify for tracks...
+          </Typography>
+        </Box>
+      )}
+
+      {results.length > 0 && !isProcessing && (
+        <Box mb={3}>
+          <Typography variant="h6" gutterBottom>
+            Search Results
+          </Typography>
+          <Box mb={2}>
+            <Chip 
+              label={`${foundCount}/${totalCount} tracks found`} 
+              color={foundCount === totalCount ? "primary" : "default"}
+            />
+          </Box>
+          {results.map((result, index) => (
+            <TrackResult key={index} result={result} index={index} />
+          ))}
+        </Box>
+      )}
+
+      <CoverArtGrid coverArtData={coverArtData} />
+      
+      <MarkdownOutput markdown={markdown} />
+    </div>
+  );
+}
+
+export default TracklistProcessor;

--- a/src/components/TracklistProcessor.js
+++ b/src/components/TracklistProcessor.js
@@ -40,6 +40,10 @@ const useStyles = makeStyles((theme) => ({
     width: '100%',
     height: 'auto',
     borderRadius: theme.spacing(1),
+    display: 'block',
+  },
+  coverGridItem: {
+    aspectRatio: '1 / 1', // Force square aspect ratio
   },
   trackResult: {
     marginBottom: theme.spacing(1),
@@ -761,7 +765,7 @@ function TrackResult({ result, index, onUpdateResult, apiToken }) {
   );
 }
 
-function CoverArtGrid({ coverArtData }) {
+function CoverArtGrid({ coverArtData, textColor }) {
   const classes = useStyles();
   
   if (coverArtData.length === 0) {
@@ -769,13 +773,10 @@ function CoverArtGrid({ coverArtData }) {
   }
 
   return (
-    <div className={classes.coverGrid}>
-      <Typography variant="h5" gutterBottom>
-        Cover art grid
-      </Typography>
+    <div className={classes.coverGrid} style={{ marginTop: '2em' }}>
       <Grid container spacing={2}>
         {coverArtData.map((cover, index) => (
-          <Grid item xs={6} sm={4} md={3} lg={2} key={index}>
+          <Grid item xs={3} sm={3} md={3} lg={3} key={index} className={classes.coverGridItem}>
             <img 
               src={cover.coverImageUrl} 
               alt={`${cover.artistName} - ${cover.albumName}`}
@@ -806,14 +807,58 @@ function PlaylistCanvas({ coverArtData, markdown, backgroundColor, textColor }) 
   };
 
   return (
-    <div className={classes.playlistCanvas}>
+    <div className={classes.playlistCanvas} style={{ marginTop: '2em' }}>
       {/* Controls */}
-      <Box display="flex" alignItems="center" gap={4} mb={2}>
+      <Box 
+        display="flex" 
+        justifyContent="space-between"
+        alignItems="center" 
+        mb={2}
+        style={{ 
+          backgroundColor: backgroundColor,
+          color: textColor,
+          padding: '12px',
+          borderRadius: '8px',
+          border: `1px solid ${textColor}40` // 25% opacity border
+        }}
+      >
+        {/* Left Margin Control */}
+        <Box display="flex" alignItems="center" gap={1}>
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={() => adjustLeftMargin(-0.5)}
+            style={{ 
+              minWidth: '30px', 
+              padding: '4px',
+              color: textColor,
+              borderColor: textColor,
+              backgroundColor: 'transparent'
+            }}
+          >
+            ←
+          </Button>
+          <Typography variant="body2" style={{ minWidth: '50px', textAlign: 'center', color: textColor }}>
+            {leftMargin}em
+          </Typography>
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={() => adjustLeftMargin(0.5)}
+            style={{ 
+              minWidth: '30px', 
+              padding: '4px',
+              color: textColor,
+              borderColor: textColor,
+              backgroundColor: 'transparent'
+            }}
+          >
+            →
+          </Button>
+        </Box>
+        
         {/* Font Size Control */}
         <Box display="flex" alignItems="center" gap={1} minWidth={150}>
-          <Typography variant="body2" style={{ minWidth: 'fit-content' }}>
-            Font size:
-          </Typography>
           <input
             type="range"
             min="12"
@@ -822,35 +867,9 @@ function PlaylistCanvas({ coverArtData, markdown, backgroundColor, textColor }) 
             onChange={(e) => setFontSize(parseInt(e.target.value))}
             style={{ flex: 1 }}
           />
-          <Typography variant="body2" style={{ minWidth: '30px' }}>
+          <Typography variant="body2" style={{ minWidth: '30px', color: textColor }}>
             {fontSize}px
           </Typography>
-        </Box>
-        
-        {/* Left Margin Control */}
-        <Box display="flex" alignItems="center" gap={1}>
-          <Typography variant="body2" style={{ minWidth: 'fit-content' }}>
-            Left margin:
-          </Typography>
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={() => adjustLeftMargin(-0.5)}
-            style={{ minWidth: '30px', padding: '4px' }}
-          >
-            ←
-          </Button>
-          <Typography variant="body2" style={{ minWidth: '50px', textAlign: 'center' }}>
-            {leftMargin}em
-          </Typography>
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={() => adjustLeftMargin(0.5)}
-            style={{ minWidth: '30px', padding: '4px' }}
-          >
-            →
-          </Button>
         </Box>
       </Box>
       
@@ -876,7 +895,7 @@ function PlaylistCanvas({ coverArtData, markdown, backgroundColor, textColor }) 
                   } else if (part.startsWith('_') && part.endsWith('_')) {
                     return <em key={idx}>{part.slice(1, -1)}</em>;
                   } else if (part === '[NZ]') {
-                    return <span key={idx} style={{ color: '#1976d2', fontWeight: 'bold' }}>{part}</span>;
+                    return <span key={idx} style={{ fontWeight: 'bold' }}>{part}</span>;
                   } else {
                     return <span key={idx} style={{ color: 'inherit' }}>{part}</span>;
                   }
@@ -971,7 +990,7 @@ function ColorPickerFooter({ backgroundColor, setBackgroundColor, textColor, set
   );
 }
 
-function MarkdownOutput({ markdown }) {
+function MarkdownOutput({ markdown, textColor }) {
   const classes = useStyles();
   
   if (!markdown) {
@@ -985,10 +1004,18 @@ function MarkdownOutput({ markdown }) {
   return (
     <div>
       <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
-        <Typography variant="h5">
+        <Typography variant="h5" style={{ color: textColor }}>
           Tracklist markdown
         </Typography>
-        <Button variant="outlined" size="small" onClick={handleCopy}>
+        <Button 
+          variant="outlined" 
+          size="small" 
+          onClick={handleCopy}
+          style={{
+            color: textColor,
+            borderColor: textColor
+          }}
+        >
           Copy to clipboard
         </Button>
       </Box>
@@ -1010,20 +1037,6 @@ function TracklistProcessor() {
   const [markdown, setMarkdown] = useState('');
   const [backgroundColor, setBackgroundColor] = useState('#ffffff'); // Default background color
   const [textColor, setTextColor] = useState('#000000'); // Default text color
-
-  const pickColor = async (setColor) => {
-    if ('EyeDropper' in window) {
-      try {
-        const eyeDropper = new window.EyeDropper();
-        const result = await eyeDropper.open();
-        setColor(result.sRGBHex);
-      } catch (error) {
-        console.log('User cancelled color picker or error occurred:', error);
-      }
-    } else {
-      alert('Color picker is not supported in this browser. Please use Chrome or Edge.');
-    }
-  };
 
   const handleUpdateResult = (index, updatedResult) => {
     const newResults = [...results];
@@ -1082,7 +1095,7 @@ function TracklistProcessor() {
     <div className={classes.container} style={{ backgroundColor, minHeight: '100vh', paddingBottom: '80px' }}>
       <div className={classes.header}>
         <div>
-          <Typography variant="h4" gutterBottom>
+          <Typography variant="h4" gutterBottom style={{ color: textColor }}>
             Tracklist to cover art & markdown
           </Typography>
           <Chip 
@@ -1093,7 +1106,7 @@ function TracklistProcessor() {
         </div>
       </div>
       
-      <Typography variant="body1" gutterBottom color="textSecondary">
+      <Typography variant="body1" gutterBottom style={{ color: textColor }}>
         Paste your tracklist below and we'll search Spotify to generate a cover art grid and formatted markdown.
       </Typography>
 
@@ -1107,6 +1120,15 @@ function TracklistProcessor() {
         value={tracklistText}
         onChange={(e) => setTracklistText(e.target.value)}
         disabled={isProcessing}
+        style={{
+          backgroundColor: 'white',
+        }}
+        InputProps={{
+          style: {
+            backgroundColor: 'white',
+            color: 'black',
+          }
+        }}
       />
 
       <Button
@@ -1123,7 +1145,7 @@ function TracklistProcessor() {
       {isProcessing && (
         <Box mb={3}>
           <LinearProgress />
-          <Typography variant="body2" align="center" style={{ marginTop: 8 }}>
+          <Typography variant="body2" align="center" style={{ marginTop: 8, color: textColor }}>
             Searching Spotify for tracks...
           </Typography>
         </Box>
@@ -1131,7 +1153,7 @@ function TracklistProcessor() {
 
       {results.length > 0 && !isProcessing && (
         <Box mb={3}>
-          <Typography variant="h6" gutterBottom>
+          <Typography variant="h6" gutterBottom style={{ color: textColor }}>
             Search results
           </Typography>
           <Box mb={2}>
@@ -1156,6 +1178,10 @@ function TracklistProcessor() {
               color="primary"
               onClick={handleAddTrack}
               startIcon={<span>+</span>}
+              style={{
+                color: textColor,
+                borderColor: textColor
+              }}
             >
               Add track
             </Button>
@@ -1163,11 +1189,11 @@ function TracklistProcessor() {
         </Box>
       )}
 
-      <CoverArtGrid coverArtData={coverArtData} />
+      <CoverArtGrid coverArtData={coverArtData} textColor={textColor} />
       
       <PlaylistCanvas coverArtData={coverArtData} markdown={markdown} backgroundColor={backgroundColor} textColor={textColor} />
       
-      <MarkdownOutput markdown={markdown} />
+      <MarkdownOutput markdown={markdown} textColor={textColor} />
       
       {/* Sticky Color Picker Footer */}
       <ColorPickerFooter 

--- a/src/lib/tracklistProcessor.js
+++ b/src/lib/tracklistProcessor.js
@@ -1,0 +1,113 @@
+import { baseUrl, spotifyFetch } from "./spotify-api";
+
+/**
+ * Parse a pasted tracklist text into individual track strings
+ * Handles various formats like numbered lists, artist - title, etc.
+ */
+export function parseTracklistText(text) {
+  if (!text || !text.trim()) {
+    return [];
+  }
+
+  return text
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+    .map(line => {
+      // Remove common prefixes like "1. ", "01 ", etc.
+      return line.replace(/^\d+\.?\s*/, '').trim();
+    })
+    .filter(line => line.length > 0);
+}
+
+/**
+ * Search Spotify for a track and return detailed results
+ */
+export async function searchForTrack(spotifyAccessToken, trackText) {
+  const url = new URL(baseUrl + "search");
+  url.searchParams.append("type", "track");
+  url.searchParams.append("q", trackText);
+  url.searchParams.append("limit", "5"); // Get multiple results for user to choose from
+
+  try {
+    const response = await spotifyFetch({ spotifyAccessToken, url });
+    const tracks = response?.tracks?.items || [];
+    
+    return {
+      originalText: trackText,
+      tracks: tracks,
+      bestMatch: tracks[0] || null,
+      found: tracks.length > 0
+    };
+  } catch (error) {
+    console.error(`Error searching for track: ${trackText}`, error);
+    return {
+      originalText: trackText,
+      tracks: [],
+      bestMatch: null,
+      found: false,
+      error: error.message
+    };
+  }
+}
+
+/**
+ * Process an entire tracklist by searching for each track
+ */
+export async function processTracklist(spotifyAccessToken, tracklistText) {
+  const trackStrings = parseTracklistText(tracklistText);
+  const results = [];
+
+  for (const trackText of trackStrings) {
+    const searchResult = await searchForTrack(spotifyAccessToken, trackText);
+    results.push(searchResult);
+    
+    // Add a small delay to avoid rate limiting
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  return results;
+}
+
+/**
+ * Generate cover art data from processed tracks
+ */
+export function generateCoverArtData(processedTracks) {
+  return processedTracks
+    .filter(result => result.bestMatch)
+    .map(result => {
+      const track = result.bestMatch;
+      const album = track.album;
+      
+      return {
+        albumId: album.id,
+        albumName: album.name,
+        artistName: track.artists.map(a => a.name).join(', '),
+        coverImageUrl: album.images[0]?.url,
+        trackName: track.name,
+        originalText: result.originalText
+      };
+    });
+}
+
+/**
+ * Generate markdown tracklist from processed tracks
+ */
+export function generateMarkdownTracklist(processedTracks) {
+  let markdown = '';
+  
+  processedTracks.forEach((result, index) => {
+    const trackNumber = index + 1;
+    
+    if (result.bestMatch) {
+      const track = result.bestMatch;
+      const artists = track.artists.map(a => a.name).join(' + ');
+      markdown += `${trackNumber}. **${artists}** – _${track.name}_\n`;
+    } else {
+      // Track not found - include original text
+      markdown += `${trackNumber}. **${result.originalText}** – _[NOT FOUND]_\n`;
+    }
+  });
+  
+  return markdown;
+}

--- a/src/store/app/index.js
+++ b/src/store/app/index.js
@@ -4,7 +4,7 @@ const slice = createSlice({
   name: "spotifyClient",
   initialState: {
     apiToken: "",
-    view: "playlists",
+    view: "tracklist-processor",
   },
   reducers: {
     setApiToken(state, action) {

--- a/src/theme.js
+++ b/src/theme.js
@@ -28,7 +28,7 @@ const theme = createMuiTheme({
   //     main: orange.A400,
   //   },
     background: {
-      default: "orange",
+      default: "#f2f1f3",
     },
   //   action: {
   //     selected: "green",


### PR DESCRIPTION
Paste a tracklist and generate cover grid, tracklist, and markdown tracklist assets. 

- customise search or specify spotify ID to get songs right
- add custom songs with cover art 
- override/customise the markdown formatting of the artist/title
- pick bg/fg colour for tracklist pic
- tweak tracklist font size and margin to taste
- hide songs (e.g. duplicates or failed custom items)
- mark tunes as NZ producer/artist

Note there is still no export, manually screenshot the visual assets, copy paste the markdown.

Built with major assist from GitHub Copilot, approx $2 in tokens.

<img width="1269" height="385" alt="Screenshot 2025-08-09 at 4 01 48 PM" src="https://github.com/user-attachments/assets/42892be8-fee8-4b02-96af-9537aa606c77" />
<img width="1243" height="480" alt="Screenshot 2025-08-09 at 4 02 04 PM" src="https://github.com/user-attachments/assets/db58e7e6-3441-4faf-ba23-ea9b647942d0" />
<img width="1264" height="658" alt="Screenshot 2025-08-09 at 4 02 14 PM" src="https://github.com/user-attachments/assets/824a38d9-40fd-42c5-b382-49417aa93856" />
<img width="1233" height="884" alt="Screenshot 2025-08-09 at 4 02 23 PM" src="https://github.com/user-attachments/assets/2966ee91-0df5-4eac-9649-9dcecb43d6a8" />
<img width="1270" height="296" alt="Screenshot 2025-08-09 at 4 02 30 PM" src="https://github.com/user-attachments/assets/f6c7e7ea-02a5-4a9f-ab7e-46190c9be3cd" />

